### PR TITLE
Matching profiles based on activity history, fraud check and verification scores

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,10 @@
+---
+applications:
+  - name: di-ipv-gpg-45-engine
+    path: build/libs/gpg-45-engine-0.0.1-SNAPSHOT.jar
+    memory: 256M
+    buildpack: java_buildpack
+    env:
+      JAVA_HOME: "../.java-buildpack/open_jdk_jre"
+      JBP_CONFIG_OPEN_JDK_JRE: '{ jre: { version: 13.+}, memory_calculator: {stack_threads: 200}}'
+      JAVA_OPTS: '-Xss200k -XX:ReservedCodeCacheSize=50M -XX:MaxMetaspaceSize=100M'

--- a/src/main/java/uk/gov/di/gpg45engine/domain/data/BundleScores.java
+++ b/src/main/java/uk/gov/di/gpg45engine/domain/data/BundleScores.java
@@ -1,0 +1,11 @@
+package uk.gov.di.gpg45engine.domain.data;
+
+import lombok.Data;
+import uk.gov.di.gpg45engine.domain.gpg45.Score;
+
+@Data
+public class BundleScores {
+    private Score activityCheckScore = Score.NOT_AVAILABLE;
+    private Score fraudCheckScore = Score.NOT_AVAILABLE;
+    private Score identityVerificationScore = Score.NOT_AVAILABLE;
+}

--- a/src/main/java/uk/gov/di/gpg45engine/domain/data/IdentityVerificationBundle.java
+++ b/src/main/java/uk/gov/di/gpg45engine/domain/data/IdentityVerificationBundle.java
@@ -8,4 +8,5 @@ public class IdentityVerificationBundle {
     private ActivityCheck[] activityChecks;
     private FraudCheck fraudCheck;
     private IdentityVerification identityVerification;
+    private BundleScores bundleScores;
 }

--- a/src/main/java/uk/gov/di/gpg45engine/domain/data/IdentityVerificationBundle.java
+++ b/src/main/java/uk/gov/di/gpg45engine/domain/data/IdentityVerificationBundle.java
@@ -8,5 +8,5 @@ public class IdentityVerificationBundle {
     private ActivityCheck[] activityChecks;
     private FraudCheck fraudCheck;
     private IdentityVerification identityVerification;
-    private BundleScores bundleScores;
+    private BundleScores bundleScores = new BundleScores();
 }

--- a/src/main/java/uk/gov/di/gpg45engine/domain/gpg45/EvidenceScore.java
+++ b/src/main/java/uk/gov/di/gpg45engine/domain/gpg45/EvidenceScore.java
@@ -1,7 +1,6 @@
 package uk.gov.di.gpg45engine.domain.gpg45;
 
 import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/uk/gov/di/gpg45engine/matchers/ScoreMatcher.java
+++ b/src/main/java/uk/gov/di/gpg45engine/matchers/ScoreMatcher.java
@@ -7,4 +7,8 @@ public class ScoreMatcher {
     public static boolean equalsOrGreater(Score score, Score score2) {
         return score.getScoreValue() >= score2.getScoreValue();
     }
+
+    public static boolean greater(Score score, Score score2) {
+        return score.getScoreValue() >= score2.getScoreValue();
+    }
 }

--- a/src/main/java/uk/gov/di/gpg45engine/services/ProfileMatchingService.java
+++ b/src/main/java/uk/gov/di/gpg45engine/services/ProfileMatchingService.java
@@ -1,9 +1,10 @@
 package uk.gov.di.gpg45engine.services;
 
 import uk.gov.di.gpg45engine.domain.data.IdentityEvidence;
+import uk.gov.di.gpg45engine.domain.data.IdentityVerificationBundle;
 import uk.gov.di.gpg45engine.domain.gpg45.IdentityProfile;
 
 public interface ProfileMatchingService {
 
-    IdentityProfile matchEvidenceScoringToProfile(IdentityEvidence[] evidenceBundle);
+    IdentityProfile matchBundleToProfile(IdentityVerificationBundle bundle);
 }

--- a/src/main/java/uk/gov/di/gpg45engine/services/ProfileMatchingService.java
+++ b/src/main/java/uk/gov/di/gpg45engine/services/ProfileMatchingService.java
@@ -1,6 +1,5 @@
 package uk.gov.di.gpg45engine.services;
 
-import uk.gov.di.gpg45engine.domain.data.IdentityEvidence;
 import uk.gov.di.gpg45engine.domain.data.IdentityVerificationBundle;
 import uk.gov.di.gpg45engine.domain.gpg45.IdentityProfile;
 

--- a/src/main/java/uk/gov/di/gpg45engine/services/impl/Gpg45ServiceImpl.java
+++ b/src/main/java/uk/gov/di/gpg45engine/services/impl/Gpg45ServiceImpl.java
@@ -10,7 +10,7 @@ import uk.gov.di.gpg45engine.services.Gpg45Service;
 import uk.gov.di.gpg45engine.services.IdentityEvidenceService;
 import uk.gov.di.gpg45engine.services.ProfileMatchingService;
 
-import java.util.*;
+import java.util.Arrays;
 
 @Service
 public class Gpg45ServiceImpl implements Gpg45Service {

--- a/src/main/java/uk/gov/di/gpg45engine/services/impl/Gpg45ServiceImpl.java
+++ b/src/main/java/uk/gov/di/gpg45engine/services/impl/Gpg45ServiceImpl.java
@@ -29,14 +29,17 @@ public class Gpg45ServiceImpl implements Gpg45Service {
 
     @Override
     public CalculateResponseDto calculate(IdentityVerificationBundle bundle) {
-        mapIdentityEvidenceToScore(bundle.getIdentityEvidence());
-        var identityProfile = profileMatchingService.matchEvidenceScoringToProfile(bundle.getIdentityEvidence());
+        var scoredEvidence = mapIdentityEvidenceToScore(bundle.getIdentityEvidence());
+
+        bundle.setIdentityEvidence(scoredEvidence);
+        var identityProfile = profileMatchingService.matchBundleToProfile(bundle);
 
         return new CalculateResponseDto(bundle, identityProfile);
     }
 
-    private void mapIdentityEvidenceToScore(IdentityEvidence[] identityEvidence) {
-        Arrays.stream(identityEvidence).forEach(evidence -> {
+    private IdentityEvidence[] mapIdentityEvidenceToScore(IdentityEvidence[] identityEvidence) {
+        var evidenceBundle = identityEvidence.clone();
+        Arrays.stream(evidenceBundle).forEach(evidence -> {
 
             if (evidence.getEvidenceScore() != null) {
                 // if score is already provided skip scoring step, useful for playing about with values.
@@ -49,5 +52,7 @@ public class Gpg45ServiceImpl implements Gpg45Service {
 
             evidence.setEvidenceScore(evidenceScore);
         });
+
+        return evidenceBundle;
     }
 }

--- a/src/main/java/uk/gov/di/gpg45engine/services/impl/ProfileMatchingServiceImpl.java
+++ b/src/main/java/uk/gov/di/gpg45engine/services/impl/ProfileMatchingServiceImpl.java
@@ -33,6 +33,7 @@ public class ProfileMatchingServiceImpl implements ProfileMatchingService {
     public IdentityProfile matchBundleToProfile(IdentityVerificationBundle bundle) {
         var possibleMatches = new ArrayList<IdentityProfile>();
 
+        var bundleScores = bundle.getBundleScores();
         var evidenceBundle = bundle.getIdentityEvidence();
         var evidenceScores = Arrays.stream(evidenceBundle)
             .map(IdentityEvidence::getEvidenceScore)
@@ -50,8 +51,12 @@ public class ProfileMatchingServiceImpl implements ProfileMatchingService {
                 }
 
                 // Compare the other 3 things to see if they match or not.
-//                if (ScoreMatcher.equalsOrGreater(evidenceBundle))
-
+                if (ScoreMatcher.greater(identityProfile.getActivityHistory(), bundleScores.getActivityCheckScore())
+                && ScoreMatcher.greater(identityProfile.getIdentityFraud(), bundleScores.getFraudCheckScore())
+                && ScoreMatcher.greater(identityProfile.getVerification(), bundleScores.getIdentityVerificationScore())) {
+                    // skip the identity profile as we don't match the other 3 scores
+                    return;
+                }
 
                 var matchedEvidences = new ArrayList<EvidenceScore>();
                 var matchedCriteria = new ArrayList<EvidenceScore>();

--- a/src/main/java/uk/gov/di/gpg45engine/services/impl/ProfileMatchingServiceImpl.java
+++ b/src/main/java/uk/gov/di/gpg45engine/services/impl/ProfileMatchingServiceImpl.java
@@ -55,6 +55,10 @@ public class ProfileMatchingServiceImpl implements ProfileMatchingService {
                 && ScoreMatcher.greater(identityProfile.getIdentityFraud(), bundleScores.getFraudCheckScore())
                 && ScoreMatcher.greater(identityProfile.getVerification(), bundleScores.getIdentityVerificationScore())) {
                     // skip the identity profile as we don't match the other 3 scores
+                    log.debug(
+                        "Skipped profile (activity history, identity fraud, verification is lower than required): {}",
+                        identityProfile.getDescription()
+                    );
                     return;
                 }
 

--- a/src/main/java/uk/gov/di/gpg45engine/services/impl/ProfileMatchingServiceImpl.java
+++ b/src/main/java/uk/gov/di/gpg45engine/services/impl/ProfileMatchingServiceImpl.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import uk.gov.di.gpg45engine.domain.data.IdentityEvidence;
+import uk.gov.di.gpg45engine.domain.data.IdentityVerificationBundle;
 import uk.gov.di.gpg45engine.domain.gpg45.EvidenceScore;
 import uk.gov.di.gpg45engine.domain.gpg45.IdentityProfile;
 import uk.gov.di.gpg45engine.matchers.ScoreMatcher;
@@ -29,9 +30,10 @@ public class ProfileMatchingServiceImpl implements ProfileMatchingService {
     }
 
     @Override
-    public IdentityProfile matchEvidenceScoringToProfile(IdentityEvidence[] evidenceBundle) {
+    public IdentityProfile matchBundleToProfile(IdentityVerificationBundle bundle) {
         var possibleMatches = new ArrayList<IdentityProfile>();
 
+        var evidenceBundle = bundle.getIdentityEvidence();
         var evidenceScores = Arrays.stream(evidenceBundle)
             .map(IdentityEvidence::getEvidenceScore)
             .collect(Collectors.toList());
@@ -48,6 +50,7 @@ public class ProfileMatchingServiceImpl implements ProfileMatchingService {
                 }
 
                 // Compare the other 3 things to see if they match or not.
+//                if (ScoreMatcher.equalsOrGreater(evidenceBundle))
 
 
                 var matchedEvidences = new ArrayList<EvidenceScore>();


### PR DESCRIPTION
## Whats changed

- Renaming some methods to make their names more appropriate.
- Mapping identity evidence to score without touching the original bundle.
- Can pass some bundle scores for activity histroy, verification and fraud checks.