### PR TITLE
PYI-55: Adding uuid for each evidence.

### DIFF
--- a/src/main/java/uk/gov/di/gpg45engine/domain/data/IdentityEvidence.java
+++ b/src/main/java/uk/gov/di/gpg45engine/domain/data/IdentityEvidence.java
@@ -3,8 +3,11 @@ package uk.gov.di.gpg45engine.domain.data;
 import lombok.Data;
 import uk.gov.di.gpg45engine.domain.gpg45.EvidenceScore;
 
+import java.util.UUID;
+
 @Data
 public class IdentityEvidence {
+    private UUID uuid;
     private EvidenceType type;
     private Object evidenceData;
     private ValidityCheck validityChecks;

--- a/src/main/java/uk/gov/di/gpg45engine/services/impl/IdentityEvidenceServiceImpl.java
+++ b/src/main/java/uk/gov/di/gpg45engine/services/impl/IdentityEvidenceServiceImpl.java
@@ -38,6 +38,11 @@ public class IdentityEvidenceServiceImpl implements IdentityEvidenceService {
     @Override
     public Score getEvidenceValidity(IdentityEvidence identityEvidence) {
         var score = Score.NOT_AVAILABLE;
+
+        if (identityEvidence.getValidityChecks() == null) {
+            return Score.NOT_AVAILABLE;
+        }
+
         var authoritativeSource = identityEvidence.getValidityChecks().getAuthoritativeSource();
 
         if (approvedAuthoritativeSources.contains(authoritativeSource)) {


### PR DESCRIPTION
## Whats changed

- Adding UUID for each evidence so we can track the flow easier in logs.
- If we have no validity checks, return a not available or score of 0.